### PR TITLE
[#179252161] bump golang to 1.16

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/alphagov/paas-prometheus-endpoints
 
-go 1.15
+go 1.16
 
 require (
 	code.cloudfoundry.org/lager v2.0.0+incompatible

--- a/manifest-redis.yml
+++ b/manifest-redis.yml
@@ -15,7 +15,7 @@ applications:
       - route: ((route))
 
     env:
-      GOVERSION: go1.15
+      GOVERSION: go1.16
       GOPACKAGENAME: github.com/alphagov/paas-prometheus-endpoints/src/redis
       GO_INSTALL_PACKAGE_SPEC: github.com/alphagov/paas-prometheus-endpoints/src/redis
       GIN_MODE: release


### PR DESCRIPTION
## What

Bump the required version of golang in the module and cf manifest to 1.16, because we're about to roll out a buildpack which removes 1.15.

## How to review

Set a dev pipeline's `paas-prometheus-endpoints` resource's `branch` to this one?

## Who can review

Human engineers.

---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
