### PR TITLE
Go update to 1.22

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/alphagov/paas-prometheus-endpoints
 
-go 1.23
+go 1.22
 
 require (
 	code.cloudfoundry.org/lager v2.0.0+incompatible

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/alphagov/paas-prometheus-endpoints
 
-go 1.21
+go 1.23
 
 require (
 	code.cloudfoundry.org/lager v2.0.0+incompatible

--- a/manifest-redis.yml
+++ b/manifest-redis.yml
@@ -15,7 +15,7 @@ applications:
       - route: ((route))
 
     env:
-      GOVERSION: go1.21
+      GOVERSION: go1.23
       GOPACKAGENAME: github.com/alphagov/paas-prometheus-endpoints/src/redis
       GO_INSTALL_PACKAGE_SPEC: github.com/alphagov/paas-prometheus-endpoints/src/redis
       GIN_MODE: release

--- a/manifest-redis.yml
+++ b/manifest-redis.yml
@@ -15,7 +15,7 @@ applications:
       - route: ((route))
 
     env:
-      GOVERSION: go1.23
+      GOVERSION: go1.22
       GOPACKAGENAME: github.com/alphagov/paas-prometheus-endpoints/src/redis
       GO_INSTALL_PACKAGE_SPEC: github.com/alphagov/paas-prometheus-endpoints/src/redis
       GIN_MODE: release


### PR DESCRIPTION
What
----
Go update to 1.22

> Initially intended to upgrade go to 1.23, but reverted to 1.22 due to current buildpack compatibility. Buildpack doesn't yet support 1.23.

How to review
-----

Testing and code review

Who can review
-----

PaaS team members
